### PR TITLE
add C/D/F letter cases to fully cover GetFinalGrade

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+grade-calculator/coverage.txt
+coverage.txt

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 grade-calculator/coverage.txt
 coverage.txt
+coverage.txt
+grade-calculator/coverage.txt

--- a/grade-calculator/grade_calculator_test.go
+++ b/grade-calculator/grade_calculator_test.go
@@ -2,50 +2,127 @@ package esepunittests
 
 import "testing"
 
-func TestGetGradeA(t *testing.T) {
-	expected_value := "A"
+// basic sanity check: all 100s should be an A
+func TestGetGradeA_AllHundreds(t *testing.T) {
+	gc := NewGradeCalculator()
+	gc.AddGrade("a1", 100, Assignment)
+	gc.AddGrade("e1", 100, Exam)
+	gc.AddGrade("s1", 100, Essay)
+
+	got := gc.GetFinalGrade()
+	if got != "A" {
+		t.Errorf("expected A, got %s", got)
+	}
+}
+
+// numbers around low 80s should average to a B with the given weights
+func TestGetGradeB_MixedLow80s(t *testing.T) {
+	// 0.5*80 + 0.35*81 + 0.15*85 = 81.1 → B
+	gc := NewGradeCalculator()
+	gc.AddGrade("a1", 80, Assignment)
+	gc.AddGrade("e1", 81, Exam)
+	gc.AddGrade("s1", 85, Essay)
+
+	got := gc.GetFinalGrade()
+	if got != "B" {
+		t.Errorf("expected B, got %s", got)
+	}
+}
+
+// this used to be tested as F, but the math is actually ~96.9 which is an A
+func TestGetGrade_ShouldBeA_NotF(t *testing.T) {
+	gc := NewGradeCalculator()
+	gc.AddGrade("a1", 100, Assignment)
+	gc.AddGrade("e1", 95, Exam)
+	gc.AddGrade("s1", 91, Essay)
+
+	got := gc.GetFinalGrade()
+	if got != "A" {
+		t.Errorf("expected A, got %s", got)
+	}
+}
+
+// quick boundary checks for the >= rules
+func TestBoundaries(t *testing.T) {
+	t.Run("exactly 90 is A", func(t *testing.T) {
+		gc := NewGradeCalculator()
+		gc.AddGrade("a1", 90, Assignment)
+		gc.AddGrade("e1", 90, Exam)
+		gc.AddGrade("s1", 90, Essay)
+		if g := gc.GetFinalGrade(); g != "A" {
+			t.Errorf("expected A at 90, got %s", g)
+		}
+	})
+
+	t.Run("exactly 80 is B", func(t *testing.T) {
+		gc := NewGradeCalculator()
+		gc.AddGrade("a1", 80, Assignment)
+		gc.AddGrade("e1", 80, Exam)
+		gc.AddGrade("s1", 80, Essay)
+		if g := gc.GetFinalGrade(); g != "B" {
+			t.Errorf("expected B at 80, got %s", g)
+		}
+	})
+}
+
+// no essays entered → essay avg should be 0, not a crash
+func TestEmptyEssays_CountsAsZero(t *testing.T) {
+	// 0.5*100 + 0.35*100 + 0.15*0 = 85 → B
+	gc := NewGradeCalculator()
+	gc.AddGrade("a1", 100, Assignment)
+	gc.AddGrade("e1", 100, Exam)
+
+	if g := gc.GetFinalGrade(); g != "B" {
+		t.Errorf("expected B with no essays, got %s", g)
+	}
+}
+
+// just making sure the String() names are wired up
+func TestGradeTypeString_NotEmpty(t *testing.T) {
+	if Assignment.String() == "" || Exam.String() == "" || Essay.String() == "" {
+		t.Fatalf("expected non-empty names for grade types")
+	}
+}
+
+func TestGetGradeC_AllSeventies(t *testing.T) {
+	expected_value := "C"
 
 	gradeCalculator := NewGradeCalculator()
-
-	gradeCalculator.AddGrade("open source assignment", 100, Assignment)
-	gradeCalculator.AddGrade("exam 1", 100, Exam)
-	gradeCalculator.AddGrade("essay on ai ethics", 100, Essay)
+	gradeCalculator.AddGrade("a1", 70, Assignment)
+	gradeCalculator.AddGrade("e1", 70, Exam)
+	gradeCalculator.AddGrade("s1", 70, Essay)
 
 	actual_value := gradeCalculator.GetFinalGrade()
-
 	if expected_value != actual_value {
 		t.Errorf("Expected GetGrade to return '%s'; got '%s' instead", expected_value, actual_value)
 	}
 }
 
-func TestGetGradeB(t *testing.T) {
-	expected_value := "B"
+func TestGetGradeD_AllSixties(t *testing.T) {
+	expected_value := "D"
 
 	gradeCalculator := NewGradeCalculator()
-
-	gradeCalculator.AddGrade("open source assignment", 80, Assignment)
-	gradeCalculator.AddGrade("exam 1", 81, Exam)
-	gradeCalculator.AddGrade("essay on ai ethics", 85, Essay)
+	gradeCalculator.AddGrade("a1", 60, Assignment)
+	gradeCalculator.AddGrade("e1", 60, Exam)
+	gradeCalculator.AddGrade("s1", 60, Essay)
 
 	actual_value := gradeCalculator.GetFinalGrade()
-
 	if expected_value != actual_value {
 		t.Errorf("Expected GetGrade to return '%s'; got '%s' instead", expected_value, actual_value)
 	}
 }
 
-func TestGetGradeF(t *testing.T) {
+func TestGetGradeF_AllZeros(t *testing.T) {
 	expected_value := "F"
 
 	gradeCalculator := NewGradeCalculator()
-
-	gradeCalculator.AddGrade("open source assignment", 100, Assignment)
-	gradeCalculator.AddGrade("exam 1", 95, Exam)
-	gradeCalculator.AddGrade("essay on ai ethics", 91, Essay)
+	gradeCalculator.AddGrade("a1", 0, Assignment)
+	gradeCalculator.AddGrade("e1", 0, Exam)
+	gradeCalculator.AddGrade("s1", 0, Essay)
 
 	actual_value := gradeCalculator.GetFinalGrade()
-
 	if expected_value != actual_value {
 		t.Errorf("Expected GetGrade to return '%s'; got '%s' instead", expected_value, actual_value)
 	}
 }
+


### PR DESCRIPTION
Part 2: Fixed README path (grade-calculator) and added coverage commands.

Part 3: Fixed bugs in library (essay average, averaging loop, empty-slice guard) and corrected the wrong “F” test.

Part 4: Added tests for C/D/F and edge cases to reach full coverage.

Part 5: Wrote up notes on coverage vs. correctness.

Coverage after my Updates: C:\Users\nithila\esep-grade-calculator\grade-calculator>go tool cover -func=coverage.txt
esep/grade-calculator/grade_calculator.go:23:   String                  100.0%
esep/grade-calculator/grade_calculator.go:33:   NewGradeCalculator      100.0%
esep/grade-calculator/grade_calculator.go:41:   GetFinalGrade           100.0%
esep/grade-calculator/grade_calculator.go:56:   AddGrade                100.0%
esep/grade-calculator/grade_calculator.go:67:   calculateNumericalGrade 100.0%
esep/grade-calculator/grade_calculator.go:81:   computeAverage          100.0%
total:                                          (statements)            100.0%

Notes: weights 50/35/15; letter scale A≥90, B≥80, C≥70, D≥60